### PR TITLE
Develop (#25)

### DIFF
--- a/src/components/editor/EditorPane.tsx
+++ b/src/components/editor/EditorPane.tsx
@@ -9,12 +9,14 @@ export default function EditorPane({
   onChange,
   onSave,
   readOnly = false,
+  canSave = true,
 }: {
   initialContent: string;
   theme: string;
   onChange: (doc: string) => void;
   onSave: () => void;
   readOnly?: boolean;
+  canSave?: boolean;
 }) {
   const editorRef = useRef<HTMLDivElement>(null);
   const viewRef = useRef<EditorView | null>(null);
@@ -136,7 +138,7 @@ export default function EditorPane({
         const saveKeymap = {
           key: "Mod-s",
           run: () => {
-            if (!readOnly) {
+            if (!readOnly && canSave) {
               onSaveRef.current();
             }
             return true;

--- a/src/components/editor/Toolbar.tsx
+++ b/src/components/editor/Toolbar.tsx
@@ -32,6 +32,7 @@ export const Toolbar = memo(function Toolbar({
   user,
   isOwner,
   isBusy,
+  canSave,
 }: {
   projectTitle?: string;
   isSaving: boolean;
@@ -48,6 +49,7 @@ export const Toolbar = memo(function Toolbar({
   user: User;
   isOwner: boolean;
   isBusy?: boolean;
+  canSave?: boolean;
 }) {
   const [shareModalOpen, setShareModalOpen] = useState(false);
 
@@ -108,7 +110,7 @@ export const Toolbar = memo(function Toolbar({
             variant="ghost"
             size="sm"
             onClick={onSave}
-            disabled={isSaving || !hasUnsavedChanges}
+            disabled={isSaving || !hasUnsavedChanges || !canSave}
           >
             <Save className="mr-2 h-4 w-4" />
             Save

--- a/src/lib/projectService.ts
+++ b/src/lib/projectService.ts
@@ -21,7 +21,7 @@ export async function fetchUserProjects(
   page: number = 0,
   pageSize: number = PAGE_SIZE,
   filter: FilterType = "owned",
-  userId: string,
+  userId: string
 ): Promise<{
   projects: ProjectWithShares[];
   hasMore: boolean;
@@ -49,7 +49,7 @@ export async function fetchUserProjects(
           *,
           project_shares!inner(shared_with)
         `,
-          { count: "exact" },
+          { count: "exact" }
         )
         .eq("project_shares.shared_with", userId)
         .order("updated_at", { ascending: false })
@@ -108,7 +108,7 @@ export async function searchUserProjects(
   page: number = 0,
   pageSize: number = PAGE_SIZE,
   filter: FilterType = "owned",
-  userId: string,
+  userId: string
 ): Promise<{
   projects: ProjectWithShares[];
   hasMore: boolean;
@@ -137,7 +137,7 @@ export async function searchUserProjects(
           *,
           project_shares!inner(shared_with)
         `,
-          { count: "exact" },
+          { count: "exact" }
         )
         .eq("project_shares.shared_with", userId)
         .ilike("title", `%${searchQuery.trim()}%`)
@@ -195,7 +195,7 @@ export async function searchUserProjects(
 }
 
 export async function fetchUserProjectById(
-  projectId: string,
+  projectId: string
 ): Promise<Project | null> {
   try {
     const supabase = getAdminClient();
@@ -219,7 +219,7 @@ export async function createProjectFromTemplate(
   userId: string,
   title: string,
   template: Template,
-  projectType: "resume" | "document" = "document",
+  projectType: "resume" | "document" = "document"
 ): Promise<Project> {
   const projectId = crypto.randomUUID();
   const typPath = `${userId}/${projectId}/main.typ`;
@@ -301,7 +301,7 @@ export async function loadProjectFile(path: string): Promise<string> {
 /* ---------- Create new project with initial file ---------- */
 export async function createNewProject(
   userId: string,
-  title: string = "Untitled Document",
+  title: string = "Untitled Document"
 ): Promise<Project> {
   try {
     const projectId = crypto.randomUUID();
@@ -351,7 +351,7 @@ export async function saveProjectFile(
   projectId: string,
   typPath: string,
   code: string,
-  pdfContent?: PDFContent,
+  pdfContent?: PDFContent
 ): Promise<void> {
   try {
     const supabase = getAdminClient();
@@ -374,7 +374,7 @@ export async function saveProjectFile(
         const thumbnailPath = `${typPath.replace(".typ", "_thumb.png")}`;
         const storedPathOrUrl = await generateAndUploadThumbnail(
           pdfContent,
-          thumbnailPath,
+          thumbnailPath
         );
 
         // Update database with thumbnail path or public URL
@@ -389,7 +389,7 @@ export async function saveProjectFile(
         if (thumbnailUpdateError) {
           console.error(
             "Failed to update thumbnail path:",
-            thumbnailUpdateError,
+            thumbnailUpdateError
           );
         }
       } catch (thumbnailError) {
@@ -404,7 +404,7 @@ export async function saveProjectFile(
 /* ---------- Rename project ---------- */
 export async function renameProject(
   projectId: string,
-  newTitle: string,
+  newTitle: string
 ): Promise<Project> {
   try {
     const supabase = getAdminClient();
@@ -433,7 +433,7 @@ export async function renameProject(
 export async function deleteProject(
   projectId: string,
   typPath: string,
-  thumbnail_path?: string,
+  thumbnail_path?: string
 ): Promise<void> {
   try {
     const supabase = getAdminClient();


### PR DESCRIPTION
* Lcp optimization on old pdf approach (#21)

* LCP optimization on pdf approach

* compilation fix when navigating to editor page

* optimizing extra with SSR

* more optimization with SSR

* showing one common loader for better LCP and avoiding layout shifts

* solve editor not loading in readonly mode

* app-level global typst provider

* Revert "app-level global typst provider"

This reverts commit b0372bde8f2881f4759741aca41169ab32d9f293.

* cleanup

* tyring global typst instance approach

* Revert "tyring global typst instance approach"

This reverts commit 43be0922efc26097d59cec372c490c91d3e358ac.

* cleanup

* populating blank doc with some content

* #updated: removed new doc button for non-cxo users and showing all documents to cxos (#23)

* #Fixed: all document access for cxo and loader on blank document (#24)