### PR TITLE
fix: stop dependabot version bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    ignore:
+      - dependency-name: "*"


### PR DESCRIPTION
Since we don't need to update every minor version, security scanning is enabled we can upgrade whenever there is a issue

> [!IMPORTANT]
>
> 1. Make sure you have read our [contribution guidelines](https://github.com/infocusp-fullstack/typst/blob/main/CONTRIBUTING.md)
> 2. Ensure there is an associated issue and you have been assigned to it
> 3. Use the correct syntax to link this PR: `Fixes #<issue number>`.

## Summary

<!-- Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change. -->

## Checklist

- [ ] This change requires a documentation update, if yes I have updated the relevant documentation: [README.MD](https://github.com/infocusp-fullstack/typst/blob/main/README.md) and [env.example](https://github.com/infocusp-fullstack/typst/blob/main/env.example)
- [x] I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x] I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.